### PR TITLE
Update referentialIntegrity options

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,12 +1,11 @@
 datasource db {
   provider             = "mysql"
   url                  = env("DATABASE_URL")
-  referentialIntegrity = "prisma"
+  relationMode = "prisma"
 }
 
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["referentialIntegrity"]
 }
 
 model User {


### PR DESCRIPTION
Prisma has changed the way they handle relations and referential integrity is no longer a preview options